### PR TITLE
Add the possibility to configure where yolact publishes

### DIFF
--- a/config/yolact_config.yaml
+++ b/config/yolact_config.yaml
@@ -15,3 +15,4 @@ yolact_ros2_node:
     score_threshold: 0.0
     crop_masks: True
     top_k: 5
+    publish_namespace: /yolact_ros2

--- a/yolact_ros2/yolact_ros2.py
+++ b/yolact_ros2/yolact_ros2.py
@@ -68,8 +68,6 @@ class YolactNode(Node):
         publish_ns = self.get_parameter('publish_namespace')._value
         self.image_pub = self.create_publisher(Image, f'{publish_ns}/visualization', 1)
         self.detections_pub = self.create_publisher(Detections, f'{publish_ns}/detections', 1)
-        self.image_pub = self.create_publisher(Image, '/yolact_ros2/visualization', 1)
-        self.detections_pub = self.create_publisher(Detections, '/yolact_ros2/detections', 1)
         self.setParams_()
 
         # Set Reconfigurable parameters Callback:

--- a/yolact_ros2/yolact_ros2.py
+++ b/yolact_ros2/yolact_ros2.py
@@ -39,8 +39,7 @@ class YolactNode(Node):
         self.model_path = None
         self.image_sub = None
         self.received_img = None
-        self.image_pub = self.create_publisher(Image, '/yolact_ros2/visualization', 1)
-        self.detections_pub = self.create_publisher(Detections, '/yolact_ros2/detections', 1)
+        
         self.image_vis_queue = Queue(maxsize = 1)
         self.visualization_thread = None
         self.unpause_visualization = threading.Event()
@@ -63,9 +62,14 @@ class YolactNode(Node):
             ('display_fps', self.display_fps_),
             ('score_threshold', self.score_threshold_),
             ('crop_masks', self.crop_masks_),
-            ('top_k', self.top_k_)
+            ('top_k', self.top_k_),
+            ('publish_namespace', '/yolact_ros2')
         ])
-
+        publish_ns = self.get_parameter('publish_namespace')._value
+        self.image_pub = self.create_publisher(Image, f'{publish_ns}/visualization', 1)
+        self.detections_pub = self.create_publisher(Detections, f'{publish_ns}/detections', 1)
+        self.image_pub = self.create_publisher(Image, '/yolact_ros2/visualization', 1)
+        self.detections_pub = self.create_publisher(Detections, '/yolact_ros2/detections', 1)
         self.setParams_()
 
         # Set Reconfigurable parameters Callback:


### PR DESCRIPTION
Right now, you cannot easily change how topics are called. It can be useful to make that configurable. Using that, you can compare multiple yolact configurations, i.e. different weights, for example. 